### PR TITLE
Extend new-project to update OctoCatalog

### DIFF
--- a/cmd/new_project.go
+++ b/cmd/new_project.go
@@ -21,6 +21,7 @@ The project will be added with default commands: git pull, docker compose build,
 			// Define file paths
 			projectsFile := "source/its-the-vibe/SlackCompose/projects.json.tmpl"
 			dispatcherFile := "source/its-the-vibe/github-dispatcher/config.json.tmpl"
+			catalogFile := "source/its-the-vibe/OctoCatalog/catalog.json.tmpl"
 
 			// Default commands as specified in the issue
 			defaultCommands := []string{
@@ -43,6 +44,13 @@ The project will be added with default commands: git pull, docker compose build,
 				return fmt.Errorf("failed to add project to config.json.tmpl: %w", err)
 			}
 			fmt.Printf("✓ Added project to %s\n", dispatcherFile)
+
+			// Add project to OctoCatalog catalog.json.tmpl
+			fmt.Printf("Adding project '%s' to %s...\n", projectName, catalogFile)
+			if err := utils.AddProjectToOctoCatalog(catalogFile, projectName); err != nil {
+				return fmt.Errorf("failed to add project to OctoCatalog catalog.json.tmpl: %w", err)
+			}
+			fmt.Printf("✓ Added project to %s\n", catalogFile)
 
 			fmt.Printf("\n✓ Successfully added project '%s' to configuration files!\n", projectName)
 			return nil

--- a/internal/utils/project.go
+++ b/internal/utils/project.go
@@ -119,3 +119,84 @@ func AddProjectToDispatcherConfig(filePath, projectName string, commands []strin
 
 	return nil
 }
+
+// CatalogOption represents an option entry in OctoCatalog catalog.json.tmpl
+type CatalogOption struct {
+	Text  string `json:"text"`
+	Value string `json:"value"`
+}
+
+// CatalogItem represents an action item in OctoCatalog catalog.json.tmpl
+type CatalogItem struct {
+	ActionId string          `json:"actionId"`
+	Options  []CatalogOption `json:"options"`
+}
+
+// AddProjectToOctoCatalog adds a new project option to OctoCatalog's catalog.json.tmpl under both SlackCompose and SlashVibeIssue actions
+func AddProjectToOctoCatalog(filePath, projectName string) error {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var items []CatalogItem
+	if err := json.Unmarshal(data, &items); err != nil {
+		return fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	foundSlack := false
+	foundSlash := false
+	for i, it := range items {
+		if it.ActionId == "SlackCompose" || it.ActionId == "SlashVibeIssue" {
+			// Check duplicate
+			for _, opt := range it.Options {
+				if opt.Value == projectName {
+					// mark as found for this action and continue
+					if it.ActionId == "SlackCompose" {
+						foundSlack = true
+					} else {
+						foundSlash = true
+					}
+					goto CONTINUE
+				}
+			}
+
+			// Add option
+			items[i].Options = append(items[i].Options, CatalogOption{Text: projectName, Value: projectName})
+
+			// Sort options by Text
+			sort.Slice(items[i].Options, func(a, b int) bool {
+				return items[i].Options[a].Text < items[i].Options[b].Text
+			})
+
+			if it.ActionId == "SlackCompose" {
+				foundSlack = true
+			} else {
+				foundSlash = true
+			}
+		}
+	CONTINUE:
+	}
+
+	missing := []string{}
+	if !foundSlack {
+		missing = append(missing, "SlackCompose")
+	}
+	if !foundSlash {
+		missing = append(missing, "SlashVibeIssue")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("action(s) not found in %s: %v", filePath, missing)
+	}
+
+	output, err := json.MarshalIndent(items, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, append(output, '\n'), 0644); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds project entries to the OctoCatalog catalog.json.tmpl for SlackCompose and SlashVibeIssue when running new-project.