### PR TITLE
chore: add Pearl example config template

### DIFF
--- a/source/__.OrgName__/Pearl/config.yaml.tmpl
+++ b/source/__.OrgName__/Pearl/config.yaml.tmpl
@@ -8,7 +8,7 @@ server:
 
 bigquery:
   # GCP project ID that owns the BigQuery dataset.
-  project_id: "your-gcp-project-id"
+  project_id: "{{.GcpProjectId}}"
 
   # BigQuery dataset that contains the journeys table.
-  dataset: "your_dataset"
+  dataset: "oyster"


### PR DESCRIPTION
Add config.yaml.tmpl as a template for Pearl configuration. Instructs users to copy and fill in their own values for server and BigQuery settings.